### PR TITLE
Added waf_alert.py

### DIFF
--- a/gae_dashboard/waf_alert.py
+++ b/gae_dashboard/waf_alert.py
@@ -101,7 +101,6 @@ def waf_detect(end):
         return
 
 
-
     # When an empty query is returned, these are of types ['None']. I have not typecasted yet because it harms successful attempts
     percentage = results[0]['percentage']
     blocked = results[0]['blocked']

--- a/gae_dashboard/waf_alert.py
+++ b/gae_dashboard/waf_alert.py
@@ -14,7 +14,7 @@ FASTLY_DATASET = "fastly"
 FASTLY_WAF_LOG_TABLE_PREFIX = "khanacademy_dot_org_waf_logs"
 FASTLY_LOG_TABLE_PREFIX = "khanacademy_dot_org_logs"
 
-# The size of the period of time to query. We are monitoring every 5 minutes.
+# The size of the period of time to query. We are monitoring every 60 minutes.
 WAF_PERIOD = 60 * 60
 
 # Spike percentage determined from WAF Investigation:
@@ -24,7 +24,7 @@ SPIKE_PERCENTAGE = 0.03
 TABLE_FORMAT = "%Y%m%d"
 TS_FORMAT = "%Y-%m-%d %H:%M:%S"
 
-ALERT_CHANNEL = "#bot-testing"
+ALERT_CHANNEL = "#infrastructure-sre"
 
 BLOCKED_REQ = """
 #standardSQL
@@ -160,7 +160,7 @@ def waf_detect(endtime):
             end_time=end_time,
         )
 
-         alertlib.Alert(msg).send_to_slack(ALERT_CHANNEL)
+        alertlib.Alert(msg).send_to_slack(ALERT_CHANNEL)
 
 
 def main():

--- a/gae_dashboard/waf_alert.py
+++ b/gae_dashboard/waf_alert.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+"""Periodically checks blocked requests which indicates either an attack or a problem with the WAF rules."""
+
+import re
+import datetime
+from itertools import groupby
+
+import alertlib
+import bq_util
+
+import argparse
+
+BQ_PROJECT = 'khanacademy.org:deductive-jet-827'
+FASTLY_DATASET = 'fastly'
+FASTLY_WAF_LOG_TABLE_PREFIX = 'khanacademy_dot_org_waf_logs'
+FASTLY_LOG_TABLE_PREFIX = 'khanacademy_dot_org_logs'
+
+# The size of the period of time to query. We are monitoring every 5 minutes.
+WAF_PERIOD = 5 * 60
+
+TABLE_FORMAT = '%Y%m%d'
+TS_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+
+ALERT_CHANNEL = '#bot-testing'
+
+# The fastly's timestamp field is a string with extra details denoting the time
+# zone. BigQuery doesn't understand that part, so we trim that out as the time
+# zone is always +0000.
+today = datetime.datetime.now()
+now = datetime.datetime.utcnow()
+ymd = today.strftime(TABLE_FORMAT)
+waf_log_name = BQ_PROJECT + '.' + FASTLY_DATASET + '.' + FASTLY_WAF_LOG_TABLE_PREFIX + '_' + ymd
+log_name = BQ_PROJECT + '.' + FASTLY_DATASET + '.' + FASTLY_LOG_TABLE_PREFIX + '_' + ymd
+
+QUERY_TEMPLATE = """\
+#standardSQL
+WITH BLOCKED_REQ AS (
+  SELECT
+    TIMESTAMP(timestamp) AS t,
+    count(*) AS blocked,
+    APPROX_TOP_COUNT(waf.message,1)[OFFSET(0)].value AS message,
+    APPROX_TOP_COUNT(waf.message,1)[OFFSET(0)].count AS unique_messages,
+    count(waf.message) AS total_messages,
+    APPROX_TOP_COUNT(client_ip,1)[OFFSET(0)].value AS b_ip,
+    APPROX_TOP_COUNT(request_user_agent,1)[OFFSET(0)].value AS b_request_user_agent,
+    APPROX_TOP_COUNT(request_user_agent,1)[OFFSET(0)].count AS unique_rua,
+    APPROX_TOP_COUNT(client_ip,1)[OFFSET(0)].count AS unique_ip,
+    count(client_ip) AS total_ip,
+    count(request_user_agent) AS total_rua
+  FROM
+    `{fastly_waf_log_tables}`
+  WHERE
+    (TIMESTAMP(timestamp) BETWEEN TIMESTAMP('{start_timestamp}')
+    AND TIMESTAMP('{end_timestamp}')) AND blocked=1
+  GROUP BY
+    t
+  ORDER BY
+    t DESC
+),
+TOTAL_REQ AS (
+  SELECT
+    TIMESTAMP_TRUNC(TIMESTAMP(timestamp), MINUTE) AS t,
+    count(*) AS total
+  FROM
+    `{fastly_log_tables}`
+  GROUP BY
+    t
+  ORDER BY
+    t DESC
+)
+SELECT
+  SUM(blocked) AS blocked,
+  SUM(total) AS total,
+  100 * SUM(blocked) / SUM(total) AS percentage,
+  APPROX_TOP_COUNT(b_ip,1)[OFFSET(0)].value AS ip,
+  APPROX_TOP_COUNT(message,1)[OFFSET(0)].value AS message,
+  100 * SUM(unique_messages)/SUM(total_messages) AS message_percentage,
+  APPROX_TOP_COUNT(b_request_user_agent,1)[OFFSET(0)].value AS request_user_agent,
+  100 * SUM(unique_ip)/SUM(total_ip) AS ip_percentage,
+  100 * SUM(unique_rua)/SUM(total_rua) AS rua_percentage
+FROM
+  BLOCKED_REQ
+  INNER JOIN TOTAL_REQ USING (t)
+WHERE
+  TIMESTAMP(t) BETWEEN TIMESTAMP('{start_timestamp}')
+  AND TIMESTAMP('{end_timestamp}')
+"""
+
+def waf_detect(end):
+    start = end - datetime.timedelta(seconds=WAF_PERIOD)
+    query = QUERY_TEMPLATE.format(
+        fastly_log_tables=log_name,fastly_waf_log_tables=waf_log_name,
+        start_timestamp=start.strftime(TS_FORMAT),
+        end_timestamp=end.strftime(TS_FORMAT),
+        )
+    results = bq_util.query_bigquery(query, project=BQ_PROJECT)
+
+    # Stop processing if we don't have any flagged IPs
+    if not results:
+        return
+
+
+
+    # When an empty query is returned, these are of types ['None']. I have not typecasted yet because it harms successful attempts
+    percentage = results[0]['percentage']
+    blocked = results[0]['blocked']
+    total = results[0]['total']
+    ip = results[0]['ip']
+    ip_percentage = results[0]['ip_percentage']
+    request_user_agent = results[0]['request_user_agent']
+    message = results[0]['message']
+    message_percentage = results[0]['message_percentage']
+    rua_percentage = results[0]['rua_percentage']
+
+    if ip_percentage == '(None)':
+        return
+
+    start_time = start.strftime("%H:%M")
+    end_time = end.strftime("%H:%M")
+
+    msg = """
+    :exclamation: *Possible WAF alert* :exclamation:
+    *Time Range:* {start_time} - {end_time}
+    *Blocked requests:* {percentage:.1f}% ({blocked} / {total})
+    *IP:* {ip} ({ip_percentage:.1f}% of blocks)
+    *Request User Agent:* {request_user_agent} ({rua_percentage:.1f}% of blocks)
+    *WAF Block Reason:* {message} ({message_percentage:.1f}% of blocks)
+    """.format(percentage=percentage, blocked=blocked, total=total, ip=ip, request_user_agent=request_user_agent, message=message, ip_percentage=ip_percentage, message_percentage=message_percentage, rua_percentage=rua_percentage, start_time=start_time, end_time=end_time)
+
+    alertlib.Alert(msg).send_to_slack(ALERT_CHANNEL)
+
+def main():
+    # For demoing alert against specific attack time
+    # python waf_alert.py --datetime '2021-07-23 10:03:00'
+    # NOTE: Dates will only work for after 2021-07-20
+    parser = argparse.ArgumentParser(description='Process the date and time that we want to investigate.')
+    parser.add_argument("--datetime", help="Date and time that we want to investigate.",
+     type=lambda s: datetime.datetime.strptime(s, TS_FORMAT))
+    args = parser.parse_args()
+
+    if args.datetime:
+        now = args.datetime
+    else:
+        now = datetime.datetime.utcnow()
+    waf_detect(now)
+
+if __name__ == '__main__':
+    main()

--- a/gae_dashboard/waf_alert.py
+++ b/gae_dashboard/waf_alert.py
@@ -1,152 +1,163 @@
 #!/usr/bin/env python
-"""Periodically checks blocked requests which indicates either an attack or a problem with the WAF rules."""
+"""
+Periodically checks blocked requests which indicates either
+an attack or a problem with the WAF rules.
+"""
 
-import re
 import datetime
-from itertools import groupby
 
 import alertlib
 import bq_util
 
 import argparse
 
-BQ_PROJECT = 'khanacademy.org:deductive-jet-827'
-FASTLY_DATASET = 'fastly'
-FASTLY_WAF_LOG_TABLE_PREFIX = 'khanacademy_dot_org_waf_logs'
-FASTLY_LOG_TABLE_PREFIX = 'khanacademy_dot_org_logs'
+BQ_PROJECT = "khanacademy.org:deductive-jet-827"
+FASTLY_DATASET = "fastly"
+FASTLY_WAF_LOG_TABLE_PREFIX = "khanacademy_dot_org_waf_logs"
+FASTLY_LOG_TABLE_PREFIX = "khanacademy_dot_org_logs"
 
 # The size of the period of time to query. We are monitoring every 5 minutes.
 WAF_PERIOD = 5 * 60
+
+# Spike percentage determined from WAF Investigation:
+# https://app.mode.com/editor/khanacademy/reports/f58d1ec83e48/presentation
 SPIKE_PERCENTAGE = 0.17
 
-TABLE_FORMAT = '%Y%m%d'
-TS_FORMAT = '%Y-%m-%d %H:%M:%S'
+TABLE_FORMAT = "%Y%m%d"
+TS_FORMAT = "%Y-%m-%d %H:%M:%S"
 
+ALERT_CHANNEL = "#bot-testing"
 
-ALERT_CHANNEL = '#bot-testing'
-
-# The fastly's timestamp field is a string with extra details denoting the time
-# zone. BigQuery doesn't understand that part, so we trim that out as the time
-# zone is always +0000.
-QUERY_TEMPLATE = """
+BLOCKED_REQ = """
 #standardSQL
-WITH BLOCKED_REQ AS (
+SELECT
+  SUM(x.blocked) AS blocked,
+  APPROX_TOP_COUNT(x.b_ip,1)[OFFSET(0)].value AS ip,
+  APPROX_TOP_COUNT(x.message,1)[OFFSET(0)].value AS message,
+  100 * SUM(x.unique_messages)/SUM(x.total_messages) AS message_percentage,
+  APPROX_TOP_COUNT(x.b_rua,1)[OFFSET(0)].value AS rua,
+  100 * SUM(x.unique_ip)/SUM(x.total_ip) AS ip_percentage,
+  100 * SUM(x.unique_rua)/SUM(x.total_rua) AS rua_percentage
+FROM (
   SELECT
-    TIMESTAMP_TRUNC(TIMESTAMP(timestamp), MINUTE) AS t,
-    count(*) AS blocked,
+    COUNT(*) AS blocked,
     APPROX_TOP_COUNT(waf.message,1)[OFFSET(0)].value AS message,
     APPROX_TOP_COUNT(waf.message,1)[OFFSET(0)].count AS unique_messages,
-    count(waf.message) AS total_messages,
+    COUNT(waf.message) AS total_messages,
     APPROX_TOP_COUNT(client_ip,1)[OFFSET(0)].value AS b_ip,
-    APPROX_TOP_COUNT(request_user_agent,1)[OFFSET(0)].value AS b_request_user_agent,
+    APPROX_TOP_COUNT(request_user_agent,1)[OFFSET(0)].value AS b_rua,
     APPROX_TOP_COUNT(request_user_agent,1)[OFFSET(0)].count AS unique_rua,
     APPROX_TOP_COUNT(client_ip,1)[OFFSET(0)].count AS unique_ip,
-    count(client_ip) AS total_ip,
-    count(request_user_agent) AS total_rua
+    COUNT(client_ip) AS total_ip,
+    COUNT(request_user_agent) AS total_rua
   FROM
     `{fastly_waf_log_tables}`
   WHERE
-    (TIMESTAMP(timestamp) BETWEEN TIMESTAMP('{start_timestamp}')
-    AND TIMESTAMP('{end_timestamp}')) AND blocked=1
-  GROUP BY
-    t
-  ORDER BY
-    t DESC
-),
-TOTAL_REQ AS (
-  SELECT
-    TIMESTAMP_TRUNC(TIMESTAMP(timestamp), MINUTE) AS t,
-    count(*) AS total
-  FROM
-    `{fastly_log_tables}`
-  WHERE
     TIMESTAMP(timestamp) BETWEEN TIMESTAMP('{start_timestamp}')
-    AND TIMESTAMP('{end_timestamp}')
+    AND TIMESTAMP('{end_timestamp}') AND blocked=1
   GROUP BY
-    t
-  ORDER BY
-    t DESC
-)
+    TIMESTAMP(timestamp))x
+"""
+
+TOTAL_REQ = """
+#standardsql
 SELECT
-  100*MAX(blocked/total) AS percentage,
-  APPROX_TOP_COUNT(b_ip,1)[OFFSET(0)].value AS ip,
-  APPROX_TOP_COUNT(message,1)[OFFSET(0)].value AS message,
-  100 * SUM(unique_messages)/SUM(total_messages) AS message_percentage,
-  APPROX_TOP_COUNT(b_request_user_agent,1)[OFFSET(0)].value AS request_user_agent,
-  100 * SUM(unique_ip)/SUM(total_ip) AS ip_percentage,
-  100 * SUM(unique_rua)/SUM(total_rua) AS rua_percentage
+  count(*) AS total
 FROM
-  BLOCKED_REQ
-  INNER JOIN TOTAL_REQ USING (t)
+  `{fastly_log_tables}`
 WHERE
-  TIMESTAMP(t) BETWEEN TIMESTAMP('{start_timestamp}')
+  TIMESTAMP(timestamp) BETWEEN TIMESTAMP('{start_timestamp}')
   AND TIMESTAMP('{end_timestamp}')
 """
 
-def waf_detect(end, ymd, waf_log_name, log_name):
+
+def waf_detect(end):
+    ymd = end.strftime(TABLE_FORMAT)
+    waf_log_name = (
+        BQ_PROJECT + "." + FASTLY_DATASET + "." + FASTLY_WAF_LOG_TABLE_PREFIX
+        + "_" + ymd
+    )
+    log_name = (
+        BQ_PROJECT + "." + FASTLY_DATASET + "." + FASTLY_LOG_TABLE_PREFIX +
+        "_" + ymd
+    )
     start = end - datetime.timedelta(seconds=WAF_PERIOD)
-    query = QUERY_TEMPLATE.format(
-        fastly_log_tables=log_name,fastly_waf_log_tables=waf_log_name,
+    date = end.date()
+
+    blocked_info = BLOCKED_REQ.format(
+        fastly_waf_log_tables=waf_log_name,
         start_timestamp=start.strftime(TS_FORMAT),
         end_timestamp=end.strftime(TS_FORMAT),
-        )
-    results = bq_util.query_bigquery(query, project=BQ_PROJECT)
+    )
+    blocked_results = bq_util.query_bigquery(blocked_info, project=BQ_PROJECT)
+
+    total_info = TOTAL_REQ.format(
+        fastly_log_tables=log_name,
+        start_timestamp=start.strftime(TS_FORMAT),
+        end_timestamp=end.strftime(TS_FORMAT),
+    )
+    total_results = bq_util.query_bigquery(total_info, project=BQ_PROJECT)
 
     # When an empty query is returned, these are of types ('None').
-    percentage = results[0]['percentage']
-    ip = results[0]['ip']
-    ip_percentage = results[0]['ip_percentage']
-    request_user_agent = results[0]['request_user_agent']
-    message = results[0]['message']
-    message_percentage = results[0]['message_percentage']
-    rua_percentage = results[0]['rua_percentage']
+    total = total_results[0]["total"]
+    blocked = blocked_results[0]["blocked"]
+    percentage = float(100 * float(blocked) / float(total))
 
-    if ip_percentage == '(None)':
+    ip = blocked_results[0]["ip"]
+    ip_percentage = blocked_results[0]["ip_percentage"]
+    request_user_agent = blocked_results[0]["rua"]
+    message = blocked_results[0]["message"]
+
+    if ip_percentage == "(None)":
         return
 
     start_time = start.strftime("%H:%M")
     end_time = end.strftime("%H:%M")
 
-    msg = """
-    :exclamation: *Possible WAF alert* :exclamation:
-    *Time Range:* {start_time} - {end_time}
-    *Blocked requests:* {percentage:.1f}% ({blocked} / {total})
-    *IP:* {ip} ({ip_percentage:.1f}% of blocks)
-    *Request User Agent:* {request_user_agent} ({rua_percentage:.1f}% of blocks)
-    *WAF Block Reason:* {message} ({message_percentage:.1f}% of blocks)
-    """.format(percentage=percentage, blocked=blocked, total=total, ip=ip, request_user_agent=request_user_agent, message=message, ip_percentage=ip_percentage, message_percentage=message_percentage, rua_percentage=rua_percentage, start_time=start_time, end_time=end_time)
-
     if percentage > SPIKE_PERCENTAGE:
         msg = """
         :exclamation: *Possible WAF alert* :exclamation:
-        *Time Range:* {start_time} - {end_time}
+        *Date and Time:* {date}, {start_time} - {end_time}
         *Blocked requests:* {percentage:.2f}%
-        *IP:* {ip} ({ip_percentage:.1f}% of blocks)
-        *Request User Agent:* {request_user_agent} ({rua_percentage:.1f}% of blocks)
-        *WAF Block Reason:* {message} ({message_percentage:.1f}% of blocks)
-        """.format(percentage=percentage, ip=ip, request_user_agent=request_user_agent, message=message, ip_percentage=ip_percentage, message_percentage=message_percentage, rua_percentage=rua_percentage, start_time=start_time, end_time=end_time)
-
+        *IP:* {ip}
+        *Request User Agent:* {request_user_agent}
+        *WAF Block Reason:* {message}
+        """.format(
+            date=date,
+            percentage=percentage,
+            ip=ip,
+            request_user_agent=request_user_agent,
+            message=message,
+            start_time=start_time,
+            end_time=end_time,
+        )
         alertlib.Alert(msg).send_to_slack(ALERT_CHANNEL)
-    else:
-        return
+
 
 def main():
     # For demoing alert against specific attack time
     # python waf_alert.py --endtime '2021-07-23 10:03:00'
     # NOTE: Dates will only work for after 2021-07-20
-    parser = argparse.ArgumentParser(description='Process the date and time that we want to investigate.')
-    parser.add_argument("--endtime", help="Date and time that we want to investigate. For example, `python waf_alert.py --endtime '2021-07-23 10:03:00'``",
-     type=lambda s: datetime.datetime.strptime(s, TS_FORMAT))
+    parser = argparse.ArgumentParser(
+        description="Process the date and time that we want to investigate."
+    )
+    parser.add_argument(
+        "--endtime",
+        help="Date and time that we want to investigate. \
+         For example, `python waf_alert.py --endtime '2021-07-23 10:03:00'``",
+        type=lambda s: datetime.datetime.strptime(s, TS_FORMAT),
+    )
     args = parser.parse_args()
 
     if args.endtime:
         now = args.endtime
     else:
         now = datetime.datetime.utcnow()
-    ymd = now.strftime(TABLE_FORMAT)
-    waf_log_name = BQ_PROJECT + '.' + FASTLY_DATASET + '.' + FASTLY_WAF_LOG_TABLE_PREFIX + '_' + ymd
-    log_name = BQ_PROJECT + '.' + FASTLY_DATASET + '.' + FASTLY_LOG_TABLE_PREFIX + '_' + ymd
-    waf_detect(now, ymd, waf_log_name, log_name)
+    assert now > datetime.datetime(
+        2021, 7, 20
+    ), "Blocked column was introduced on 2021-07-20"
+    waf_detect(now)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary:
This script does a very simplistic check for WAF attack and notifies us via
slack if it notices anything that looks like a WAF attack.

Issue: INFRA-6453

## Changes made:
- Fixed query to ensure that we only look at fields where blocked=1
- Asserted date to only accept dates after 07/20/21
- Cleaned up alert message
- Formatting to ka-lint standards
- Added commentary for SPIKE_PERCENTAGE

## Test plan:
For the negative case:
Manually run the query for a time range where the alert > SPIKE_ALERT. For example, '2021-08-02 11:32:00' - '2021-08-02 11:37:00' and note the max ratio returned.
Run waf_alert.py with the --endtime arg as the end time. 'python waf_alert.py --endtime '2021-08-02 11:37:00'' and ensure that no alert message is sent.

For the positive case:
Manually run the query for a time range where the alert < SPIKE_ALERT. For example, '2021-08-07 05:35:00' - '2021-08-07 05:40:00' and note the max ratio returned.
Run waf_alert.py with the --endtime arg as the end time. 'python waf_alert.py --endtime '2021-08-07 05:40:00'' and ensure that an alert message is sent to bot-testing
Example message we expect to see:
![image](https://user-images.githubusercontent.com/52090947/128930612-f685231b-d793-415f-a77d-aec73655691b.png)
