### PR TITLE
Fix DOS Alerts

### DIFF
--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -66,6 +66,9 @@ FROM (
     -- Requests blocked at Fastly should be blocked much quicker than from us
     -- Note that time_elapsed is in microseconds.
     AND NOT (status == 403 AND time_elapsed <= 500)
+    -- Requests that are quick redirects don't make it to our servers, so the
+    -- impact is only on Fastly
+    AND NOT (status == 308)
   GROUP BY
     request_id)
 WHERE


### PR DESCRIPTION
## Summary:
Fix the DOS alerts to ignore 308 redirects, which should be handled by
Fastly and not hit our servers.

Issue: none

## Test plan:
Run script and make sure it no longer has the current alert spam