### PR TITLE
Fix for if there are no blocked requests

### DIFF
--- a/gae_dashboard/waf_alert.py
+++ b/gae_dashboard/waf_alert.py
@@ -1,15 +1,5 @@
 #!/usr/bin/env python
-"""Check request logs to look for an in progress WAF attack.
-
-This script does a very simplistic check for WAF attack and notifies us via
-slack if it notices anything that looks like a WAF attack.
-
-Note: we are only checking for two simple types of attacks - a single
-client requesting the same URL repeatedly, and scratchpad spam.
-
-The hope is that this alerting will allow us to blacklist the offending IP
-address using the appengine firewall.
-"""
+"""Periodically checks blocked requests which indicates either an attack or a problem with the WAF rules."""
 
 import re
 import datetime
@@ -18,12 +8,14 @@ from itertools import groupby
 import alertlib
 import bq_util
 
+import argparse
+
 BQ_PROJECT = 'khanacademy.org:deductive-jet-827'
 FASTLY_DATASET = 'fastly'
 FASTLY_WAF_LOG_TABLE_PREFIX = 'khanacademy_dot_org_waf_logs'
 FASTLY_LOG_TABLE_PREFIX = 'khanacademy_dot_org_logs'
 
-# The size of the period of time to query.
+# The size of the period of time to query. We are monitoring every 5 minutes.
 WAF_PERIOD = 5 * 60
 
 TABLE_FORMAT = '%Y%m%d'
@@ -36,15 +28,16 @@ ALERT_CHANNEL = '#bot-testing'
 # zone. BigQuery doesn't understand that part, so we trim that out as the time
 # zone is always +0000.
 today = datetime.datetime.now()
-d1 = today.strftime(TABLE_FORMAT)
-waf_log_name = BQ_PROJECT + '.' + FASTLY_DATASET + '.' + FASTLY_WAF_LOG_TABLE_PREFIX + '_' + d1
-log_name = BQ_PROJECT + '.' + FASTLY_DATASET + '.' + FASTLY_LOG_TABLE_PREFIX + '_' + d1
+now = datetime.datetime.utcnow()
+ymd = today.strftime(TABLE_FORMAT)
+waf_log_name = BQ_PROJECT + '.' + FASTLY_DATASET + '.' + FASTLY_WAF_LOG_TABLE_PREFIX + '_' + ymd
+log_name = BQ_PROJECT + '.' + FASTLY_DATASET + '.' + FASTLY_LOG_TABLE_PREFIX + '_' + ymd
 
 QUERY_TEMPLATE = """\
 #standardSQL
 WITH BLOCKED_REQ AS (
   SELECT
-    TIMESTAMP_TRUNC(TIMESTAMP(timestamp), MINUTE) AS t,
+    TIMESTAMP(timestamp) AS t,
     count(*) AS blocked,
     APPROX_TOP_COUNT(waf.message,1)[OFFSET(0)].value AS message,
     APPROX_TOP_COUNT(waf.message,1)[OFFSET(0)].count AS unique_messages,
@@ -57,6 +50,9 @@ WITH BLOCKED_REQ AS (
     count(request_user_agent) AS total_rua
   FROM
     `{fastly_waf_log_tables}`
+  WHERE
+    (TIMESTAMP(timestamp) BETWEEN TIMESTAMP('{start_timestamp}')
+    AND TIMESTAMP('{end_timestamp}')) AND blocked=1
   GROUP BY
     t
   ORDER BY
@@ -93,18 +89,19 @@ WHERE
 
 def waf_detect(end):
     start = end - datetime.timedelta(seconds=WAF_PERIOD)
-
     query = QUERY_TEMPLATE.format(
         fastly_log_tables=log_name,fastly_waf_log_tables=waf_log_name,
         start_timestamp=start.strftime(TS_FORMAT),
         end_timestamp=end.strftime(TS_FORMAT),
         )
+
     results = bq_util.query_bigquery(query, project=BQ_PROJECT)
 
     # Stop processing if we don't have any flagged IPs
     if not results:
         return
 
+    # When an empty query is returned, these are of types ['None']. I have not typecasted yet because it harms successful attempts
     percentage = results[0]['percentage']
     blocked = results[0]['blocked']
     total = results[0]['total']
@@ -115,22 +112,36 @@ def waf_detect(end):
     message_percentage = results[0]['message_percentage']
     rua_percentage = results[0]['rua_percentage']
 
+    if ip_percentage == '(None)':
+        return
+
+    start_time = start.strftime("%H:%M")
+    end_time = end.strftime("%H:%M")
+
     msg = """
-    TEST Possible WAF alert
-    {percentage:.1f}% ({blocked} / {total}) of requests blocked in the last 5 minutes
-    IP: {ip} ({ip_percentage:.1f}% of blocks)
-    Request User Agent: {request_user_agent} ({rua_percentage:.1f}% of blocks)
-    WAF Block Reason: {message} ({message_percentage:.1f}% of blocks)
-    """.format(percentage=percentage, blocked=blocked, total=total, ip=ip, request_user_agent=request_user_agent, message=message, ip_percentage=ip_percentage, message_percentage=message_percentage, rua_percentage=rua_percentage)
+    :exclamation: *Possible WAF alert* :exclamation:
+    *Time Range:* {start_time} - {end_time}
+    *Blocked requests:* {percentage:.1f}% ({blocked} / {total})
+    *IP:* {ip} ({ip_percentage:.1f}% of blocks)
+    *Request User Agent:* {request_user_agent} ({rua_percentage:.1f}% of blocks)
+    *WAF Block Reason:* {message} ({message_percentage:.1f}% of blocks)
+    """.format(percentage=percentage, blocked=blocked, total=total, ip=ip, request_user_agent=request_user_agent, message=message, ip_percentage=ip_percentage, message_percentage=message_percentage, rua_percentage=rua_percentage, start_time=start_time, end_time=end_time)
 
     alertlib.Alert(msg).send_to_slack(ALERT_CHANNEL)
 
 def main():
-    now = datetime.datetime.utcnow()
     # For demoing alert against specific attack time
-    # ./waf_alert '2021-07-08 11:00:00'
-    #if sys.argv[1]:
-    #    now = datatime.datetime.parse(sys.argv[1])
+    # python waf_alert.py --datetime '2021-07-23 10:03:00'
+    # NOTE: Dates will only work for after 2021-07-20
+    parser = argparse.ArgumentParser(description='Process the date and time that we want to investigate. If not given, defaults to now.')
+    parser.add_argument("--datetime", help="Date and time that we want to investigate.",
+     type=lambda s: datetime.datetime.strptime(s, TS_FORMAT))
+    args = parser.parse_args()
+
+    if args.date:
+        now = args.date
+    else:
+        now = datetime.datetime.utcnow()
     waf_detect(now)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary:
In cases where there are no blocked requests, the query will return a table with all column values as '(None)'. This PR mainly handles this edge case and will exit the program instead of throwing a type error as it did previously. It also includes documentation and variable naming fixes.

Issue: INFRA-6453

## Test plan:

- Find a datetime where there is a query returning 'None' (i.e.'2021-07-23 10:03:00') and ensure that no error comes and that nothing shows up on the Slack bot-testing channel

- Find a datetime where there is a query that returns a valid output (i.e. '2021-07-28 16:30:00') and ensure that an alert message comes on the bot-testing Slack channel