### PR TITLE
Fixed empty query, changed datetime arg

### DIFF
--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -66,6 +66,9 @@ FROM (
     -- Requests blocked at Fastly should be blocked much quicker than from us
     -- Note that time_elapsed is in microseconds.
     AND NOT (status == 403 AND time_elapsed <= 500)
+    -- Requests that are quick redirects don't make it to our servers, so the
+    -- impact is only on Fastly
+    AND NOT (status == 308)
   GROUP BY
     request_id)
 WHERE


### PR DESCRIPTION
## Summary:
In cases where there are no blocked requests, the query will return a table with all column values as '(None)'. This PR mainly handles this edge case and will exit the program instead of throwing a type error as it did previously. It also includes documentation and variable naming fixes.

Issue: INFRA-6453

## Test plan:

- Find a date and time where there is a query returning 'None' and ensure that no error comes and that nothing shows up on the Slack bot-testing channel. An example is `python waf_alert.py --datetime '2021-07-23 10:03:00'`

- Find a date and time where there is a query that returns a valid output (i.e. '2021-07-28 16:30:00') and ensure that an alert message comes on the bot-testing Slack channel. An example is `python waf_alert.py --datetime '2021-07-28 16:30:00'`