### PR TITLE
Alerts when spike detected

### DIFF
--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -66,6 +66,9 @@ FROM (
     -- Requests blocked at Fastly should be blocked much quicker than from us
     -- Note that time_elapsed is in microseconds.
     AND NOT (status == 403 AND time_elapsed <= 500)
+    -- Requests that are quick redirects don't make it to our servers, so the
+    -- impact is only on Fastly
+    AND NOT (status == 308)
   GROUP BY
     request_id)
 WHERE


### PR DESCRIPTION
## Summary:
This feature branch from PR #10 includes the following changes:
- Ensures that the correct logs are fetched if the --endtime arg is specified (previously, it was fetching the current date despite the arg being specified)
- Simplified the query to only fetch the max percentage within the 5 minutes
- Alerts the slack channel if the percentage is above a certain threshold SPIKE_PERCENTAGE. This threshold was created from [WAF Investigation](https://app.mode.com/editor/khanacademy/reports/f58d1ec83e48)

Issue: INFRA-6453

## Test plan:
#  For the positive case:
- Manually run the query for a time range where the alert > SPIKE_ALERT. For example, '2021-08-02 11:32:00' - '2021-08-02 11:36:59' and note the max ratio returned.
- Run waf_alert.py with the --endtime arg as the end time. 'python waf_alert.py --endtime '2021-08-02 11:37:00'' and ensure that an alert message is sent to bot-testing
#  For the negative case:
- Manually run the query for a time range where the alert < SPIKE_ALERT. For example, '2021-08-02 11:36:00' - '2021-08-02 11:40:59' and note the max ratio returned.
- Run waf_alert.py with the --endtime arg as the end time. 'python waf_alert.py --endtime '2021-08-02 11:41:00'' and ensure that no alert message is sent