### PR TITLE
Make WAF alert less noisy.

### DIFF
--- a/gae_dashboard/waf_alert.py
+++ b/gae_dashboard/waf_alert.py
@@ -19,7 +19,11 @@ WAF_PERIOD = 60 * 60
 
 # Spike percentage determined from WAF Investigation:
 # https://app.mode.com/editor/khanacademy/reports/f58d1ec83e48/presentation
-SPIKE_PERCENTAGE = 0.03
+
+# As of Nov 2021 we've decided to set this to a high value since we
+# mostly want to be alerted in cases where we're receiving significant
+# bad traffic.
+SPIKE_PERCENTAGE = 1.0
 
 TABLE_FORMAT = "%Y%m%d"
 TS_FORMAT = "%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
## Summary:
Originally when we set up with WAF blocking alert we were worried
about the WAF blocking legit traffic and wanted to be alerted so that
we could validate the the traffic was actually bad.

At this point we have a fair amount of confidence in the WAF blocking
bad traffic and so the alert is currently not useful.

This change makes the alert much less sensitive. Now it will only notify
us if significant traffic is being blocked by the WAF. In these cases
we might want to take additional action such as talk with security folks
or implement an IP block.

I set the threshold to 1% which is a guess of where we might want
it. I looked at a bunch of historical alerts and they were are in the
neighbourhood of 0.1% so this threshold should reduce noise. In terms
of whether 1% is the right amount at which we care, I'm not sure. This
is probably worth discussing in code review.

Issue: https://khanacademy.atlassian.net/browse/INFRA-6953

## Test plan:
- None