### PR TITLE
Stop Showing IP Info for Safelist only IPs

### DIFF
--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -270,14 +270,18 @@ def dos_detect(end):
     msg = DOS_ALERT_INTRO
     any_alerts_seen = False
     for ip, rows in ip_groups:
-        # For each IP, we show some default links...
-        msg += DOS_ALERT_IP_INTRO_TEMPLATE.format(ip=ip)
+        alerted_ip = False
         for row in rows:
             to_alert = not any([
                 re.match(filter_regex, row['url'])
                 for filter_regex in DOS_SAFELIST_URL_REGEX
             ])
             if to_alert:
+                # Once for each IP, we show some default links...
+                if not alerted_ip:
+                    msg += DOS_ALERT_IP_INTRO_TEMPLATE.format(ip=ip)
+                    alerted_ip = True
+
                 # ... and then list any routes/UAs this IP is spamming
                 msg += DOS_ALERT_IP_COUNT_TEMPLATE.format(**row)
                 any_alerts_seen = True


### PR DESCRIPTION
## Summary:
For the DoS alert, we were showing IP address info for all IPs, even if
they were only hitting safelisted routes. This only mattered if there
was also an IP hitting a non-safelist route, in which case we would show
an alert with the IP information of all IPs in our Slack alert, which is
confusing.

Now we only print it once for each IP addess only after we know it is
hitting a non-safelisted route.

Issue: https://khanacademy.atlassian.net/browse/INFRA-7341

## Test plan:
Run `python ./gae_dashboard/dos_alert.py`
Make sure the script runs and doesn't crash
Deploy and wait until a DoS spike to check and make sure this is fixed