### PR TITLE
[🔥AUDIT🔥] Adding local_day to sailthru_campaign_export_schema.json

### DIFF
--- a/gae_dashboard/sailthru_campaign_export_schema.json
+++ b/gae_dashboard/sailthru_campaign_export_schema.json
@@ -212,5 +212,10 @@
         "mode": "NULLABLE",
         "name": "schedule_type",
         "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "local_day",
+        "type": "STRING"
     }
 ]


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
`local_day` is now being sent to us from sailthru during one of the blast exports. We need to "allow-list" that field to stop the export from failing

Slack Thread: https://khanacademy.slack.com/archives/C8BFYFQ4C/p1645386972799869

Issue: MP-3435

## Test plan:
- n/a