### PR TITLE
[🔥AUDIT🔥] Add local_time to sailthru_campaign_export_schema.json

### DIFF
--- a/gae_dashboard/sailthru_campaign_export_schema.json
+++ b/gae_dashboard/sailthru_campaign_export_schema.json
@@ -217,5 +217,10 @@
         "mode": "NULLABLE",
         "name": "local_day",
         "type": "STRING"
+    },
+    {
+        "mode": "NULLABLE",
+        "name": "local_time",
+        "type": "STRING"
     }
 ]


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
The sailthru_to_bigquery.py job is failing again due to another var being passed in which we must now allow-list. The error in the log is `No such field: local_time`. Adding this field to sailthru_campaign_export_schema.json will stop this error from happening.

Issue: None

## Test plan:
- let it run tomorrow, verify no errors