### PR TITLE
Tidy up noisy non-actionable alerts

### DIFF
--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -30,11 +30,15 @@ ROUTES_EXPECTED_TO_FAIL = frozenset((
 ))
 
 BAD_ROUTES_RE = [
-    # Graphql queries that don't include a query name are expected to fail.
+    # Graphql queries that don't include a query name are likely to means
+    # these reqs from 3rd party scripts that we don't care if they error,
+    # especially a lot of them will be blocked by GraphQL safelist and 400.
     re.compile(
         r'^api_main:/api/internal/(_mt/)?graphql'
         '(/persist_(across_publish|across_deploy|until_publish))?'
-        '(/<path_opname>)?( \[(POST|HEAD)\])?$'),
+        '(/<path_opname>)?( \[(POST|HEAD)\])?$',
+        '/graphql/',
+    ),
     # Kotlin routes which are spam (contain non path char) are expected to fail
     # e.g. kt:/api/internal/_bb/bigbingo'||(select extractvalue(xmltype....
     re.compile(r'^kt:.*[<>|\'()]'),

--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -40,7 +40,7 @@ BAD_ROUTES_RE = [
     # For new gateway, it is okay not to include query name.
     # However these are from 3rd party scripts that we don't care if error,
     # especially a lot of them will be blocked by GraphQL safelist and 400.
-    re.compile('/graphql/'),
+    re.compile('^/graphql/$'),
     # Kotlin routes which are spam (contain non path char) are expected to fail
     # e.g. kt:/api/internal/_bb/bigbingo'||(select extractvalue(xmltype....
     re.compile(r'^kt:.*[<>|\'()]'),

--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -30,15 +30,17 @@ ROUTES_EXPECTED_TO_FAIL = frozenset((
 ))
 
 BAD_ROUTES_RE = [
-    # Graphql queries that don't include a query name are likely to means
-    # these reqs from 3rd party scripts that we don't care if they error,
-    # especially a lot of them will be blocked by GraphQL safelist and 400.
+    # Graphql queries to old monolith that  don't include a query name are
+    # expected to fail.
     re.compile(
         r'^api_main:/api/internal/(_mt/)?graphql'
         '(/persist_(across_publish|across_deploy|until_publish))?'
         '(/<path_opname>)?( \[(POST|HEAD)\])?$',
-        '/graphql/',
     ),
+    # For new gateway, it is okay not to include query name.
+    # However these are from 3rd party scripts that we don't care if error,
+    # especially a lot of them will be blocked by GraphQL safelist and 400.
+    re.compile('/graphql/'),
     # Kotlin routes which are spam (contain non path char) are expected to fail
     # e.g. kt:/api/internal/_bb/bigbingo'||(select extractvalue(xmltype....
     re.compile(r'^kt:.*[<>|\'()]'),

--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -117,6 +117,7 @@ DOS_SAFELIST_URL_REGEX = [
     r'/graphql/deleteTestUser',
     # Backfills
     r'/graphql/backfill.*',
+    r'/graphql/queueTask.*',
     # We temporaily disable this as we are getting hit hard by extension
     # https://khanacademy.slack.com/archives/C02JH0F7EHY/p1636569182038500
     # TODO (INFRA-6713): Remove this after we filter Graphql rate limiting


### PR DESCRIPTION
## Summary:
Filter out noise of a few alerts that we are seeing in the channel.

Issue: https://khanacademy.slack.com/archives/C8XGW76FQ/p1647537266324159?thread_ts=1647518408.605169&cid=C8XGW76FQ

## Test plan:
- Run manually and confirm alerts are filtered.

```
$ python check_failing_routes.py --dry-run
No routes with no 2xx requests for 03/16/22
```