### PR TITLE
[🔥AUDIT🔥] Fix email_bq_data for loglines that are just numbers.

### DIFF
--- a/gae_dashboard/email_bq_data.py
+++ b/gae_dashboard/email_bq_data.py
@@ -680,6 +680,13 @@ ORDER BY
             else:
                 sparkline_data.append(None)
         row['last 2 weeks'] = sparkline_data
+
+        # If the logline is just a number, bq will report it as an int (sigh).
+        if not isinstance(row['firstword'], basestring):
+            row['firstword'] = str(row['firstword'])
+        if not isinstance(row['sample_logline'], basestring):
+            row['sample_logline'] = str(row['sample_logline'])
+
         # While we're here, truncate the sample-logline, since it can get
         # really long.
         row['sample_logline'] = row['sample_logline'][:80]


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
If we log a message like `404`, then bq will report it as an int even
though log-messages are in the schema as strings.  Oh well, we just
handle it.  Only one place in our script cares.

Issue: https://groups.google.com/a/khanacademy.org/g/toby-admin/c/W4UemEazMLQ

## Test plan:
Fingers crossed for tomorrow's run!