### PR TITLE
Exclude login requests from triggering DoS alert.

### DIFF
--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -123,6 +123,10 @@ DOS_SAFELIST_URL_REGEX = [
     # https://khanacademy.slack.com/archives/C02JH0F7EHY/p1636569182038500
     # TODO (INFRA-6713): Remove this after we filter Graphql rate limiting
     r'/api/internal/graphql/getFullUserProfile',
+    # https://khanacademy.atlassian.net/browse/INFRA-6713 this mutation is
+    # being rate-limited but we can't see that from the fastly logs - so don't
+    # alert on it.
+    r'(/api/internal)?/graphql/LoginWithPasswordMutation.*',
 ]
 
 SCRATCHPAD_QUERY_TEMPLATE = """\


### PR DESCRIPTION
## Summary:
This mutation is now being rate limited. See
https://khanacademy.atlassian.net/browse/INFRA-6636 However we can't
detect this kind of rate limiting via the fastly logs since rate
limited graphql requests still have 200 reponse codes, not 429.

One solution would be to change the query to join the fastly table
with the request logs and look for particular logged errors in the
requests logs. I'm not sure if this would work very well - since it
would require rate limiting to log a consistent identifiable error,
and it we'd have to be sure about whether any such error in any
service that shares the traceid would be sufficient to indicate that
the request was rate-limited.

Instead I'm approaching things in a more simplistic way that requires
manual labor - safelisting the mutation.

If we end up having to do a lot more of this let's consider trying to
solve this is a more systemic way.

Issue: https://khanacademy.atlassian.net/browse/INFRA-6713

## Test plan:

None really besides looking at the change and considering it trivial.
I did run this sql query to validate the regex:
```
    SELECT
      url,
      COUNT(*)
    FROM
      `khanacademy.org:deductive-jet-827.fastly.khanacademy_dot_org_logs_20220531`
    WHERE
      REGEXP_CONTAINS(url, r'(/api/internal)?/graphql/LoginWithPasswordMutation.*')
    GROUP BY
      url
```

Unfortunately We have no real system in place to test this locally.
:-( Eventually it would be good to move scripts like this to a better
system that allowed local testing. So I'm going to deploy and hope.