### PR TITLE
[🔥AUDIT🔥] Fix the exception-check.

### DIFF
--- a/gae_dashboard/side_by_side_slack_reports.py
+++ b/gae_dashboard/side_by_side_slack_reports.py
@@ -90,9 +90,10 @@ def main():
     try:
         results = fetch_counts_from_bq(yesterday)
     except bq_util.BQException as e:
+        error_text = str(e).replace('\n', ' ')
         # This can happen if there are no side-by-side experiments
         # currently in progress.  That's not an error.
-        if 'side_by_side_result_* does not match any table' in str(e):
+        if 'side_by_side_result_* does not match any table' in error_text:
             return
         raise
 


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
It turns out there's a newline in the error text (that slack was eliding):
```
(pdb) p str(e)
"-- Query failed after 2 retries: BigQuery error in query operation: Error processing job\n'khanacademy.org:deductive-jet-827:bq_util_1672935492632373784':\nkhanacademy.org:deductive-jet-827:side_by_side.side_by_side_result_* does not\nmatch any table.\n --"
```

Issue: toby mail

## Test plan:
Fingers crossed