### PR TITLE
[🔥AUDIT🔥] Revert "[🔥AUDIT🔥] Change stance of GCP related alerts (#40)"

### DIFF
--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -19,7 +19,6 @@ sure whether this is due to a bug or by design, but I don't think it's a DoS.
 import re
 import datetime
 from itertools import groupby
-import socket
 
 import alertlib
 import bq_util
@@ -262,11 +261,6 @@ def _fastly_log_tables(start, end, period):
     ])
 
 
-def is_ip_gcp(ip):
-    hostname, _ = socket.getnameinfo((ip, 0), 0)
-    return hostname.endswith('bc.googleusercontent.com')
-
-
 def dos_detect(end):
     start = end - datetime.timedelta(seconds=DOS_PERIOD)
 
@@ -289,10 +283,10 @@ def dos_detect(end):
     for ip, rows in ip_groups:
         alerted_ip = False
         for row in rows:
-            to_alert = not (any([
+            to_alert = not any([
                 re.match(filter_regex, row['url'])
                 for filter_regex in DOS_SAFELIST_URL_REGEX
-            ]) or is_ip_gcp(ip))
+            ])
             if to_alert:
                 # Once for each IP, we show some default links...
                 if not alerted_ip:


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
Revert "[🔥AUDIT🔥] Change stance of GCP related alerts (#40)"

We have fixed the routing in
https://github.com/Khan/khanflow-pipelines/pull/875 so let's revert this
change.

This reverts commit 67aea3a28f4b292252d94ee2b6f54f0e1a13c970

Issue: XXX-XXXX

## Test plan:

n/a