### PR TITLE
Ignoring known failing routes.

### DIFF
--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -27,6 +27,10 @@ ROUTES_EXPECTED_TO_FAIL = frozenset((
     '/_ah/start.*',  # Logs show this as having null status
     'api_main:/api/v1/exercises',  # Removed API
     'main:/login/clever',  # Old clever integrations that districts removed
+
+    # TODO: https://khanacademy.atlassian.net/browse/INFRA-9293, remove these
+    '/graphql/isActivityAccessibleForProfiles',
+    '/graphql/isSatStudent',
 ))
 
 BAD_ROUTES_RE = [


### PR DESCRIPTION
## Summary:
Ignoring known failing routes `/graphql/isActivityAccessibleForProfiles` and `/graphql/isSatStudent`.

They have been triaged to not be a concern, but they are spamming #infrastructure-sre: https://khanacademy.slack.com/archives/C8XGW76FQ/p1686571207671069

They should ideally be fixed, but are temporarily being placed on the ignore list.

Issue: https://khanacademy.atlassian.net/browse/INFRA-9293

## Test plan:
SSH'd into Toby:
```
ubuntu@toby:~/internal-webserver$ python gae_dashboard/check_failing_routes.py --dry-run --date 20230611
Routes with no 2xx requests for 06/11/23:
`/graphql/isActivityAccessibleForProfiles` owned by unknown (65 requests total, 44 of them bots, 62 unique IPs)
`/graphql/isSatStudent` owned by unknown (53 requests total, 48 of them bots, 49 unique IPs)

ubuntu@toby:~/internal-webserver$ git checkout ignore-2xx 

ubuntu@toby:~/internal-webserver$ python gae_dashboard/check_failing_routes.py --dry-run --date 20230611
No routes with no 2xx requests for 06/11/23
```

Now that I know the code works, just need to `git pull` on `master` after merging.