### PR TITLE
Ignoring HEAD requests.

### DIFF
--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -52,7 +52,7 @@ BAD_ROUTES_RE = [
     # They cause falsepos with low traffic (e.g. old mobile) route
     re.compile(r'^/_gateway-proxy/.*'),
     # Spamy routes
-    re.compile(r'^/graphql/[console|graphql-playground|v1| \[POST\]$'),
+    re.compile(r'^/graphql/(console|graphql-playground|v1) \[POST\]$'),
     re.compile(r'^/graphql/schema\.\w+ \[POST\]$'),
     # HEAD requests are expected to fail
     re.compile(r'^/graphql/.* \[HEAD\]$'),

--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -52,10 +52,10 @@ BAD_ROUTES_RE = [
     # They cause falsepos with low traffic (e.g. old mobile) route
     re.compile(r'^/_gateway-proxy/.*'),
     # Spamy routes
-    re.compile(r'/graphql/[console|graphql-playground|v1| [POST]'),
-    re.compile(r'/graphql/schema\.\w+ [POST]'),
+    re.compile(r'^/graphql/[console|graphql-playground|v1| \[POST\]$'),
+    re.compile(r'^/graphql/schema\.\w+ \[POST\]$'),
     # HEAD requests are expected to fail
-    re.compile(r'/graphql/.* \[HEAD\]'),
+    re.compile(r'^/graphql/.* \[HEAD\]$'),
 ]
 
 

--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -54,6 +54,8 @@ BAD_ROUTES_RE = [
     # Spamy routes
     re.compile(r'/graphql/[console|graphql-playground|v1| [POST]'),
     re.compile(r'/graphql/schema\.\w+ [POST]'),
+    # HEAD requests are expected to fail
+    re.compile(r'^/graphql/.* [HEAD]$'),
 ]
 
 

--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -56,6 +56,8 @@ BAD_ROUTES_RE = [
     re.compile(r'^/graphql/schema\.\w+ \[POST\]$'),
     # HEAD requests are expected to fail
     re.compile(r'^/graphql/.* \[HEAD\]$'),
+    # Consistently noisy route, investigating
+    re.compile(r'^/graphql/getUrgentBanner \[POST\]$'),
 ]
 
 

--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -55,7 +55,7 @@ BAD_ROUTES_RE = [
     re.compile(r'/graphql/[console|graphql-playground|v1| [POST]'),
     re.compile(r'/graphql/schema\.\w+ [POST]'),
     # HEAD requests are expected to fail
-    re.compile(r'^/graphql/.* [HEAD]$'),
+    re.compile(r'/graphql/.* \[HEAD\]'),
 ]
 
 


### PR DESCRIPTION
## Summary:
Disable alerts for HEAD requests. We expect that all HEAD requests will fail, so no point alerting that they are.

Additionally fixing broken regexes. In testing, a noisy route (`/graphql/getUrgentBanner`) was discovered. Added that to the ignore list but will follow up on that separately.

Issue: none

## Test plan:
- SSH into Toby (`gcloud --project=khan-internal-services compute ssh 
ubuntu@toby-internal-webserver --zone=us-central1-c`)
- `cd internal-webserver/`
- `python gae_dashboard/check_failing_routes.py --date=20231205 --dry-run`
- verify failing routes with [HEAD]
- `git checkout ignore-head-requests`
- `python gae_dashboard/check_failing_routes.py --date=20231205 --dry-run`
- verify no failing routes