### PR TITLE
Fix a bug that was effectively safe listing most URLs from our DOS alerting

### DIFF
--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -134,6 +134,8 @@ DOS_SAFELIST_URL_REGEX = {
     # being rate-limited but we can't see that from the fastly logs - so don't
     # alert on it.
     r'(/api/internal)?/graphql/LoginWithPasswordMutation.*': None,
+    # The bigbingo conversion endpoint gets a lot of traffic
+    r'/api/internal/_analytics/publish_event.*': None,
     # Fastly SYNTH routes - minimal impact and we use these internally.
     r'/_fastly/.*': 100,
     r'/_api/static_version.*': 100,

--- a/gae_dashboard/dos_alert.py
+++ b/gae_dashboard/dos_alert.py
@@ -288,7 +288,11 @@ def dos_detect(end):
     for ip, rows in ip_groups:
         alerted_ip = False
         for row in rows:
-            to_alert = False
+            # We want to alert for this IP/URL combination by default. If the
+            # url matches one in the safelist, this value may be set to false.
+            # However, if it does not match anything in the safelist, we 
+            # should set off an alert.
+            to_alert = True
             # If a matching url is found, check for adjusted/overriden max
             # requests for that particular route
             # TODO(drosile): maybe refactor this to be cleaner?


### PR DESCRIPTION
## Summary:
Last March we accidentally introduced a bug which caused all but 2 url slugs to be effectively safelisted from our DOS alerting script. This happened by defaulting the `to_alert` value to false inside the loop looking at if a ip/url combination deserved to be alerted for. However, in order for an IP/URL combination to be in evaluation at that point, the IP had already had more than the default 10 reqs/sec, so the default behavior should have been 'True'. We (a few lines) later evaluate if that url is in the safelist, and may set the value to 'False' if it is.

However, by defaulting the `to_alert` variable to 'False', we effectively made it so the only urls which COULD set off a DOS alert were the ones that matched something on the safelist, which is almost entirely composed of urls which would intentionally NOT set off a DOS alert.

This change also adds a BigBingo conversion endpoint to the safelist. Shortly after the bug fix was tested, this url set off an alert. It seems likely to be normal usage though, as we get a lot of volume for this endpoint from a large number of IPs.

This code is not very easy to reason about. I'd like to address that in a follow up PR to reorganize the code a bit and hopefully add unit testing, which should hopefully make it less likely to have a bug like this make it to production.

## Test Plan:
I've already tested this by updating the code on Toby directly and it seems to work as expected. I also tested this locally by disabling the alert and setting the threshold much lower and inspecting both the results returned by the query and the message that would have been sent in the alert.