### PR TITLE
Fix the instance-hours-by-route nightly email

### DIFF
--- a/gae_dashboard/initiatives.py
+++ b/gae_dashboard/initiatives.py
@@ -83,7 +83,10 @@ def _refresh_data(path):
         if os.path.getmtime(path) > time.time() - DAY:
             # File has already been updated today, don't refresh
             return
-    subprocess.check_call([os.path.expanduser(GS_PATH), 'cp', GS_DATA, path])
+    gs_path = os.path.expanduser(GS_PATH)
+    if not os.path.exists(gs_path):
+        gs_path = 'gsutil'   # just hope it's on the path
+    subprocess.check_call([gs_path, 'cp', GS_DATA, path])
 
 
 def _load_data():


### PR DESCRIPTION
## Summary:
It was limited to only showing data from the python services, because
of Reasons.  I regenerated the cost-dict, and now we can get
instance-hour use from *all* the services.

Issue: none

## Test plan:
I can't really test locally, so I'll just deploy this and see what
happens!  It can't be worse than what exists now.