### PR TITLE
Silence alerts for AuthCookieMutation GET failures.

### DIFF
--- a/gae_dashboard/check_failing_routes.py
+++ b/gae_dashboard/check_failing_routes.py
@@ -31,6 +31,10 @@ ROUTES_EXPECTED_TO_FAIL = frozenset((
     # TODO: https://khanacademy.atlassian.net/browse/INFRA-9293, remove these
     '/graphql/isActivityAccessibleForProfiles',
     '/graphql/isSatStudent',
+
+    # TODO: https://khanacademy.atlassian.net/browse/INFRA-10181
+    # investigate where these are coming from
+    '/graphql/authcookiemutation',
 ))
 
 BAD_ROUTES_RE = [


### PR DESCRIPTION
## Summary:
Denylist `'/graphql/AuthCookieMutation'` and `/graphql/authcookiemutation` from failing routes alerting. Discussion was held about this route, but I will summarize below: 
https://khanacademy.slack.com/archives/C8XGW76FQ/p1716984015607259

We were initially worried about this because `AuthCookieMutation` is important, as it is used to refresh our KAAL cookie (see more on KA cookies at 
https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/1836613821/Authentication+and+cookies+in+webapp). However, the mutation is a POST, whereas the alert we're receiving is for a GET. On May 28, we saw 1,233 requests for 
`'/graphql/AuthCookieMutation'`, 69 requests for `/graphql/authcookiemutation`, and almost 31 million for `/graphql/AuthCookieMutation [POST]`. Query for more cookie requests here: 
https://console.cloud.google.com/bigquery?ws=!1m7!1m6!12m5!1m3!1skhanacademy.org:deductive-jet-827!2sus-central1!3sacca9fad-1b47-41b0-ba7b-147f7ede606a!2e1

We are unsure where the GET request is coming from but believe it is very low priority. A ticket to investigate this has been created: https://khanacademy.atlassian.net/browse/INFRA-10181

Note - we have NOT seen any alerts for `'/graphql/AuthCookieMutation'`, but we don't think we would want to, even if it did fail, so I've ignored it as well. Open for suggestion on this!

Issue: https://khanacademy.atlassian.net/browse/INFRA-10181

## Test plan:

To be executed, as I don't have access to Toby currently:

- SSH into Toby: https://khanacademy.atlassian.net/wiki/spaces/INFRA/pages/1986363646/DevOps+-+Toby
- From the `internal-webserver` directory: `python3 gae_dashboard/check_failing_routes.py --date=20240528 --dry-run`
  - This should show output for `/graphql/authcookiemutation`
- Checkout this branch and rerun script
- Verify no output for `/graphql/authcookiemutation`