### PR TITLE
Adding Security as a team in KA

### DIFF
--- a/gae_dashboard/initiatives.py
+++ b/gae_dashboard/initiatives.py
@@ -28,9 +28,9 @@ TEAM_EMAIL = {
     'lems': 'independent-learning-blackhole@khanacademy.org',
     'literacy': 'literacy-devs@khanacademy.org',
     'pg': 'mpp@khanacademy.org',   # product-growth
+    'security': 'security-blackhole@khanacademy.org',
     'teacher-experience': 'coached-perf-reports@khanacademy.org',
     'tutor-platform': 'independent-learning-blackhole@khanacademy.org',
-    'security': 'security-blackhole@khanacademy.org',
     'unknown': 'infrastructure-blackhole@khanacademy.org',
 }
 # TODO(amos): Maybe validate this against the loaded data.

--- a/gae_dashboard/initiatives.py
+++ b/gae_dashboard/initiatives.py
@@ -30,7 +30,7 @@ TEAM_EMAIL = {
     'pg': 'mpp@khanacademy.org',   # product-growth
     'teacher-experience': 'coached-perf-reports@khanacademy.org',
     'tutor-platform': 'independent-learning-blackhole@khanacademy.org',
-
+    'security': 'security-blackhole@khanacademy.org',
     'unknown': 'infrastructure-blackhole@khanacademy.org',
 }
 # TODO(amos): Maybe validate this against the loaded data.


### PR DESCRIPTION
## Summary:
As per the documentation linked on the follow line, KA has
(https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2774138913/EXAMPLE+New+Team+setup+checklist#Code)
a number of steps required to create a new team. This
is one of those steps.

The README here says this is deprecated but also that "A
lot of things still live here". So, I'm making this update
anyway - perhaps its one of the things still living here.

Issue: none

## Test plan:
N/A